### PR TITLE
Revert lazy size and add finite enum example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,17 @@ p Enumerator.generate { scanner.scan(%r{\d+|[-+*/]}) }.take_while { !scanner.eos
 # Potential message loop system:
 Enumerator.generate { Message.receive }.take_while { |msg| msg != :exit }
 ```
+
+### Stopping iteration early
+
+```ruby
+# Raise StopIteration to signify the end when the Enumerator is finite:
+reverse_alphabet = Enumerator.generate('z') do |char|
+  raise StopIteration if char == 'a'
+  char.ord.pred.chr
+end
+reverse_alphabet.first(3)
+#=> ["z", "y", "x"]
+reverse_alphabet.count
+#=> 26
+```

--- a/lib/enumerator_generate.rb
+++ b/lib/enumerator_generate.rb
@@ -3,7 +3,7 @@ class Enumerator
 
   def self.generate(initial = NOVALUE)
     raise ArgumentError, "No block given" unless block_given?
-    Enumerator.new(Float::INFINITY) do |y|
+    Enumerator.new do |y|
       val = initial == NOVALUE ? yield() : initial
 
       loop do

--- a/test/test_generate.rb
+++ b/test/test_generate.rb
@@ -5,7 +5,7 @@ class TestEnumerate < Test::Unit::TestCase
   def test_enumerate
     enum = Enumerator.generate(1, &:succ)
     assert_instance_of(Enumerator, enum)
-    assert_equal(Float::INFINITY, enum.size)
+    assert_equal(nil, enum.size)
     assert_equal([1, 2, 3, 4], enum.take(4))
     assert_raise(ArgumentError) { Enumerator.generate(1) }
   end
@@ -14,7 +14,7 @@ class TestEnumerate < Test::Unit::TestCase
     data = %w[foo bar baz]
     enum = Enumerator.generate { data.pop }
     assert_instance_of(Enumerator, enum)
-    assert_equal(Float::INFINITY, enum.size)
+    assert_equal(nil, enum.size)
     assert_equal(%w[baz bar foo], enum.take_while { |w| !w.nil? })
   end
 end


### PR DESCRIPTION
This closes #3 by reverting #1 and adds an example of raising StopIteration for a finite Enumerator.